### PR TITLE
docs: fix k8s example using count instead of replicas

### DIFF
--- a/website/content/partials/components/platform-kubernetes.mdx
+++ b/website/content/partials/components/platform-kubernetes.mdx
@@ -99,7 +99,7 @@ Environment variables that are meant to configure the application in a static wa
 
 deploy "kubernetes" {
 	image_secret = "registry_secret"
-	count = 3
+	replicas = 3
 	probe_path = "/_healthz"
 }
 


### PR DESCRIPTION
### Fixed

- The example suggests using a `count` config variable, and the plugin errors out when trying to use that. This changes the example variable to `replicas` (which is the one documented above)